### PR TITLE
Add OpenAPI spec and contract docs

### DIFF
--- a/docs/api_contract.md
+++ b/docs/api_contract.md
@@ -1,0 +1,47 @@
+# PDF Splitter API Contract
+
+This document describes how developers can interact with the PDF Splitter API. The service accepts PDF uploads, splits the files into manageable chunks and calls an external extraction API to generate text.
+
+## Authentication
+
+All endpoints require an API key provided in the `X-API-Key` header. Requests without a valid key will receive `403 Forbidden` responses.
+
+## Endpoints
+
+### `GET /status`
+Returns a simple status object indicating the service is running. The root path `/` behaves the same way.
+
+**Response**
+```json
+{ "status": "OK" }
+```
+
+### `GET /function_status`
+Checks if the service can reach the underlying text extraction function.
+
+- **200 OK** – the function is reachable.
+- **503 Service Unavailable** – the function is unreachable.
+
+### `POST /extract_text/`
+Uploads a PDF file and returns the combined text extracted from all pages.
+
+- **Content-Type:** `multipart/form-data`
+- **Field:** `file` – PDF file to process
+
+**Successful response**
+```json
+{
+  "metadata": {"...": "..."},
+  "text": "full text from the PDF",
+  "page_count": 42
+}
+```
+
+### Example Request
+```bash
+curl -X POST http://localhost:5006/extract_text/ \
+  -H "X-API-Key: YOUR_API_KEY" \
+  -F file=@your_document.pdf
+```
+
+For full schema details see [`openapi.yaml`](openapi.yaml).

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,126 @@
+openapi: 3.0.3
+info:
+  title: PDF Splitter API
+  description: API for splitting PDF files into chunks and extracting text using an external extraction service.
+  version: 1.0.0
+servers:
+  - url: http://localhost:5006
+    description: Local development server
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+security:
+  - ApiKeyAuth: []
+paths:
+  /status:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: Service is running
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                example:
+                  status: OK
+  /:
+    get:
+      summary: Health check (alias of /status)
+      responses:
+        '200':
+          description: Service is running
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                example:
+                  status: OK
+  /function_status:
+    get:
+      summary: Check the status of the extraction service
+      responses:
+        '200':
+          description: Extraction service is reachable
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  message:
+                    type: string
+                  pdf_extraction_api:
+                    type: string
+                  test_response:
+                    type: object
+        '503':
+          description: Extraction service is unreachable
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  message:
+                    type: string
+                  pdf_extraction_api:
+                    type: string
+                  error:
+                    type: string
+  /extract_text/:
+    post:
+      summary: Extract text from a PDF
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: Text extraction succeeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  metadata:
+                    type: object
+                  text:
+                    type: string
+                  page_count:
+                    type: integer
+        '400':
+          description: Invalid file supplied
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+        '500':
+          description: Server error during processing
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string


### PR DESCRIPTION
## Summary
- add `docs/` directory with OpenAPI spec
- document endpoints and example request for developers

## Testing
- `pytest -q`